### PR TITLE
Implement a content length check

### DIFF
--- a/LightTube/Controllers/SettingsController.cs
+++ b/LightTube/Controllers/SettingsController.cs
@@ -85,6 +85,8 @@ public class SettingsController : Controller
 		try
 		{
 			IFormFile file = Request.Form.Files[0];
+			if (file.Length is 0 or > 10 * 1024 * 1024)
+				return View(new ImportContext(HttpContext, "Imported file cannot be larger than 10 megabytes.", true));
 			using Stream fileStream = file.OpenReadStream();
 			using MemoryStream memStr = new();
 			fileStream.CopyTo(memStr);

--- a/LightTube/Views/Settings/ImportExport.cshtml
+++ b/LightTube/Views/Settings/ImportExport.cshtml
@@ -20,7 +20,7 @@
 			File
 		</div>
 		<div>
-			See below for supported formats
+			(up to 10MB) See below for supported formats
 		</div>
 	</div>
 	<div class="settings-option__option">
@@ -33,15 +33,15 @@
 <h1 class="title">Export Data</h1>
 <a href="/export/fullData.json" class="btn-blue btn-outline">Export all data as JSON</a>
 
+<h1 class="title">Supported formats for importing</h1>
+<ul>
+	<li>YouTube takeouts (.zip)</li>
+	<li>Invidious XML/OPML exports (.xml)</li>
+	<li>Invidious JSON exports (.json)</li>
+	<li>Piped playlists (.json)</li>
+	<li>Piped subscriptions (.json)</li>
+	<li>LightTube exports (.json)</li>
+</ul>
 <p>
-	<h1 class="title">Supported formats for importing</h1>
-	<ul>
-		<li>YouTube takeouts (.zip)</li>
-		<li>Invidious XML/OPML exports (.xml)</li>
-		<li>Invidious JSON exports (.json)</li>
-		<li>Piped playlists (.json)</li>
-		<li>Piped subscriptions (.json)</li>
-		<li>LightTube exports (.json)</li>
-	</ul>
 	If you need support for other websites/apps, please <a href="https://github.com/kuylar/LightTube/issues">open an issue on GitHub</a>
 </p>


### PR DESCRIPTION
# Details
Adds a content length check to the import endpoint so users don't try to upload giant YouTube export files. And maybe other stuff.

# Related issues/PRs
Closes #112 

# Changes proposed
* Add a content length check to the import endpoint
* Document the file size limit on the import page