### PR TITLE
Fix redirect URLs clashing with each other

### DIFF
--- a/LightTube/Controllers/YoutubeController.cs
+++ b/LightTube/Controllers/YoutubeController.cs
@@ -171,15 +171,6 @@ public class YoutubeController(SimpleInnerTubeClient innerTube, HttpClient clien
 			: "/");
 	}
 
-	[Route("/@{handle}")]
-	public async Task<IActionResult> ChannelFromHandle(string handle)
-	{
-			ResolveUrlResponse endpoint = await innerTube.ResolveUrl("https://youtube.com/@" + handle);
-		return Redirect(endpoint.Endpoint.EndpointTypeCase == Endpoint.EndpointTypeOneofCase.BrowseEndpoint
-			? $"/channel/{endpoint.Endpoint.BrowseEndpoint.BrowseId}"
-			: "/");
-	}
-
 	[Route("/channel/{id}")]
 	public async Task<IActionResult> Channel(string id, string? continuation = null) =>
 		await Channel(id, ChannelTabs.Featured, continuation);


### PR DESCRIPTION
# Details
`/<videoId>` and `/@<channelHandle>` was clashing with each other.

# Changes proposed
* Fixes some `/@channel` URLs throwing errors