### PR TITLE
Implement a /health endpoint

### DIFF
--- a/LightTube/ApiModels/HealthResponse.cs
+++ b/LightTube/ApiModels/HealthResponse.cs
@@ -1,0 +1,10 @@
+using InnerTube.Models;
+
+namespace LightTube.ApiModels;
+
+public class HealthResponse
+{
+	public int VideoHealth { get; set; }
+	public double AveragePlayerResponseTime { get; set; }
+	public CacheStats CacheStats { get; set; }
+}

--- a/LightTube/Health/HealthManager.cs
+++ b/LightTube/Health/HealthManager.cs
@@ -1,0 +1,30 @@
+namespace LightTube.Health;
+
+public static class HealthManager
+{
+	private static List<KeyValuePair<string, bool>> videoStatuses = [];
+	private static List<long> playerResponseTimes = [];
+
+	public static void PushVideoResponse(string videoId, bool isSuccess, long playerResponseTime)
+	{
+		if (videoStatuses.Count >= 100) videoStatuses.RemoveAt(0);
+		if (playerResponseTimes.Count >= 100) playerResponseTimes.RemoveAt(0);
+		
+		playerResponseTimes.Add(playerResponseTime);
+
+		KeyValuePair<string, bool>? oldData = videoStatuses.FirstOrDefault(x => x.Key == videoId);
+		if (oldData?.Key == null) oldData = null; // unsure why the entire thing isnt null
+
+		if (oldData?.Value == isSuccess) return;
+		videoStatuses.Add(new KeyValuePair<string, bool>(videoId, isSuccess));
+	}
+
+	public static float GetHealthPercentage() =>
+		Math.Clamp(MathF.Round((float)videoStatuses.Count(x => x.Value) / Math.Max(videoStatuses.Count, 1) * 100), 0, 100);
+
+	public static double GetAveragePlayerResponseTime()
+	{
+		if (playerResponseTimes.Count == 0) return 0;
+		 return playerResponseTimes.Average();
+	}
+}

--- a/LightTube/Health/HealthManager.cs
+++ b/LightTube/Health/HealthManager.cs
@@ -7,15 +7,17 @@ public static class HealthManager
 
 	public static void PushVideoResponse(string videoId, bool isSuccess, long playerResponseTime)
 	{
+		// don't include cache hits 
+		if (playerResponseTime < 50) return;
+
+		// if entry with the same videoId exists, remove it
+		videoStatuses.RemoveAll(x => x.Key == videoId);
+
+		// only keep last 100 requests
 		if (videoStatuses.Count >= 100) videoStatuses.RemoveAt(0);
 		if (playerResponseTimes.Count >= 100) playerResponseTimes.RemoveAt(0);
-		
+
 		playerResponseTimes.Add(playerResponseTime);
-
-		KeyValuePair<string, bool>? oldData = videoStatuses.FirstOrDefault(x => x.Key == videoId);
-		if (oldData?.Key == null) oldData = null; // unsure why the entire thing isnt null
-
-		if (oldData?.Value == isSuccess) return;
 		videoStatuses.Add(new KeyValuePair<string, bool>(videoId, isSuccess));
 	}
 


### PR DESCRIPTION
# Details
Implements a `/api/health` endpoint that contains the success rate of last 100 player requests, average player response time, and cache stats

# Changes proposed
* add /api/health. thats it

# Notes
Cache stats currently don't work because we (I) forgot to set `MemoryCache.TrackStatistics` to `true` in InnerTube.

Also, this PR ***DEPENDS*** on #169, since it calls a method that only exists in the bumped InnerTube version
